### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
+  - '6'
+  - '8'
   - '10'
+  - 'stable'
+install: npm install
 after_success:
   - 'npm run coveralls'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 environment:
   matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "11"
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
Fails on 6 and 8 due to `async / await` usage in testfiles.
Should we add `node: >= 10` to `engines`?