### PR TITLE
ci: install windows-build-tools for building node-sass from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ os:
   - windows
   - linux
   - osx
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then npm i -g windows-build-tools; fi
 after_success:
   - 'npm run coveralls'


### PR DESCRIPTION
There is no build for Windows (on Node 11) so we have to compile from source and need Python 2 and the other build tools.