### PR TITLE
remove mongodb auth from logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const server = require('./server')
 const signale = require('./utils/signale')
 const isDemo = require('./utils/isDemo')
 const fillDatabase = require('./utils/fillDatabase')
+const stripMongoSecrets = require('./utils/stripMongoSecrets')
 
 const port = process.env.ACKEE_PORT || 3000
 const url = `http://localhost:${ port }`
@@ -17,7 +18,7 @@ mongoose.set('useFindAndModify', false)
 server.on('listening', () => signale.watch(`Listening on ${ url }`))
 server.on('error', (err) => signale.fatal(err))
 
-signale.await(`Connecting to ${ process.env.ACKEE_MONGODB }`)
+signale.await(`Connecting to ${ stripMongoSecrets(process.env.ACKEE_MONGODB) }`)
 
 mongoose.connect(process.env.ACKEE_MONGODB, {
 
@@ -28,7 +29,7 @@ mongoose.connect(process.env.ACKEE_MONGODB, {
 
 }).then(() => {
 
-	signale.success(`Connected to ${ process.env.ACKEE_MONGODB }`)
+	signale.success(`Connected to ${ stripMongoSecrets(process.env.ACKEE_MONGODB) }`)
 	signale.start(`Starting the server`)
 
 	server.listen(port)

--- a/src/utils/stripMongoSecrets.js
+++ b/src/utils/stripMongoSecrets.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = (connectionUri) => {
+  if (connectionUri.indexOf('@') > -1 && connectionUri.indexOf('mongodb://' === 0)) {
+    const atIndex = connectionUri.indexOf('@')
+    return 'mongodb://' + connectionUri.slice(atIndex + 1)
+  } else {
+    return connectionUri
+  }
+}

--- a/src/utils/stripMongoSecrets.js
+++ b/src/utils/stripMongoSecrets.js
@@ -1,9 +1,12 @@
 'use strict'
 
 module.exports = (connectionUri) => {
-  if (connectionUri.indexOf('@') > -1 && connectionUri.indexOf('mongodb://' === 0)) {
+  if (typeof connectionUri === 'string' &&
+    connectionUri.indexOf('@') > -1 &&
+    connectionUri.indexOf('://') > -1) {
     const atIndex = connectionUri.indexOf('@')
-    return 'mongodb://' + connectionUri.slice(atIndex + 1)
+    const protocolIndex = connectionUri.indexOf('://')
+    return connectionUri.slice(0, protocolIndex + 3) + connectionUri.slice(atIndex + 1)
   } else {
     return connectionUri
   }

--- a/test/utils/stripMongoSecrets.js
+++ b/test/utils/stripMongoSecrets.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const test = require('ava')
+
+const stripMongoSecrets = require('../../src/utils/stripMongoSecrets')
+
+test('remove user and password when they are defined', (t) => {
+  
+  const fullUri = 'mongodb://username:password@host:port/database'
+  const expectedResult = 'mongodb://host:port/database'
+  t.is(stripMongoSecrets(fullUri), expectedResult)
+
+})
+
+test('keep uri when no username or password is set', (t) => {
+
+  const uri = 'mongodb://host:post/database'
+  t.is(stripMongoSecrets(uri), uri)
+  
+})


### PR DESCRIPTION
Putting mongodb secrets in logs is a bad idea, so I just wrote a small function to remove the username and the password from the logs.
I tried to keep consistent with the general coding style and added a test for the util function that I created. Don't hesitate to tell if you want anything changed!