### PR TITLE
Send correct content type for JavaScript files.

### DIFF
--- a/src/routes/tracker.js
+++ b/src/routes/tracker.js
@@ -5,7 +5,9 @@ const { readFile } = require('fs').promises
 const preload = require('../utils/preload')
 const isProductionEnv = require('../utils/isProductionEnv')
 
-const get = async () => {
+const get = async (req, res) => {
+
+	res.setHeader('Content-Type', 'application/javascript; charset=utf-8')
 
 	const filePath = require.resolve('ackee-tracker')
 

--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -26,7 +26,9 @@ const styles = async () => {
 
 }
 
-const scripts = async () => {
+const scripts = async (req, res) => {
+
+	res.setHeader('Content-Type', 'application/javascript; charset=utf-8')
 
 	const filePath = resolve(__dirname, '../ui/scripts/index.js')
 


### PR DESCRIPTION
The JavaScript files should be send with the correct content type header. Otherwise the browser might show a warning in th console:

![grafik](https://user-images.githubusercontent.com/1222377/66954467-becad000-f060-11e9-833f-d708b31674db.png)
