### PR TITLE
Add Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ The API of Ackee accepts information about your visitors sent to it using [ackee
 
 The interface of Ackee lets you view and analyse your tracked information.
 
+## Deploy To Heroku
+
+Want to get up and running quickly? Simply deploy to Heroku using this button:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/electerious/Ackee)
+
 ## Documentation
 
 ### Requirements

--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+    "name": "Ackee",
+    "description": "Self-hosted, Node.js based analytics tool for those who care about privacy.",
+    "keywords": [
+        "server",
+        "tracking",
+        "analytics"
+    ],
+    "website": "https://ackee.electerious.com/",
+    "repository": "https://github.com/aleccool213/Ackee",
+    "env": {
+        "ACKEE_USERNAME": {
+            "description": "Username which will be used to log in to Ackee",
+            "required": true
+        },
+        "ACKEE_PASSWORD": {
+            "description": "Passowrd which will be used to log in to Ackee",
+            "required": true
+        }
+    },
+    "addons": [
+        {
+            "plan": "mongolab"
+        }
+    ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const fillDatabase = require('./utils/fillDatabase')
 const stripUrlAuth = require('./utils/stripUrlAuth')
 
 const port = process.env.ACKEE_PORT || process.env.PORT || 3000
-const dbUrl = process.env.ACKEE_MONGODB
+const dbUrl = process.env.ACKEE_MONGODB || process.env.MONGODB_URI
 const serverUrl = `http://localhost:${ port }`
 
 mongoose.set('useFindAndModify', false)


### PR DESCRIPTION
Closes #72

* [Had to add an option for the mongo url so that Heroku-deployed Ackee can just use the default without user configuration](https://github.com/electerious/Ackee/commit/457b114827bb82fc66707f4dab672ff019fa4955)
* Adds Deploy to Heroku button 
  * [I recorded a Loom video showing it off](https://www.loom.com/share/e9fce3be4f71446a8ca3b49260f737b1)
  * To test this out on this branch, you will need to change the README link to `[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/aleccool213/Ackee/tree/72)` so that it uses the correct app.json path