### PR TITLE
Add support for multiple CORS origins

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -47,7 +47,16 @@ const catchError = (fn) => async (req, res) => {
 
 const attachCorsHeaders = (fn) => async (req, res) => {
 
-	const allowOrigin = process.env.ACKEE_ALLOW_ORIGIN
+	const allowOrigin = (() => {
+
+		if (process.env.ACKEE_ALLOW_ORIGIN === '*') return '*'
+
+		if (process.env.ACKEE_ALLOW_ORIGIN) {
+			const origins = process.env.ACKEE_ALLOW_ORIGIN.split(',')
+			return origins.find((origin) => origin.includes(req.headers.host))
+		}
+
+	})()
 
 	if (allowOrigin != null) {
 		res.setHeader('Access-Control-Allow-Origin', allowOrigin)

--- a/test/server-with-multiple-cors.js
+++ b/test/server-with-multiple-cors.js
@@ -9,12 +9,12 @@ const server = require('../src/server')
 
 const base = listen(server)
 
-test('return cors headers if env var specifies one', async (t) => {
+test('return cors headers with corresponding origin if env var specifies multiple origins', async (t) => {
 
 	const url = new URL(await base)
 
 	const restore = mockedEnv({
-		ACKEE_ALLOW_ORIGIN: url.origin
+		ACKEE_ALLOW_ORIGIN: `https://example.com,${ url.origin }`
 	})
 
 	const res = await fetch(url.href)

--- a/test/server-with-unlisted-cors.js
+++ b/test/server-with-unlisted-cors.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const test = require('ava')
+const listen = require('test-listen')
+const fetch = require('node-fetch')
+const mockedEnv = require('mocked-env')
+
+const server = require('../src/server')
+
+const base = listen(server)
+
+test('return cors headers with no origin if hostname not whitelisted in env var', async (t) => {
+
+	const url = new URL(await base)
+
+	const restore = mockedEnv({
+		ACKEE_ALLOW_ORIGIN: `https://example.com`
+	})
+
+	const res = await fetch(url.href)
+	const headers = res.headers
+
+	t.is(headers.get('Access-Control-Allow-Origin'), null)
+	t.is(headers.get('Access-Control-Allow-Methods'), null)
+	t.is(headers.get('Access-Control-Allow-Headers'), null)
+
+	restore()
+
+})

--- a/test/server-with-wildcard-cors.js
+++ b/test/server-with-wildcard-cors.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const test = require('ava')
+const listen = require('test-listen')
+const fetch = require('node-fetch')
+const mockedEnv = require('mocked-env')
+
+const server = require('../src/server')
+
+const base = listen(server)
+
+test('return cors headers if env vars specify wildcard', async (t) => {
+
+	const url = new URL(await base)
+
+	const restore = mockedEnv({
+		ACKEE_ALLOW_ORIGIN: '*'
+	})
+
+	const res = await fetch(url.href)
+	const headers = res.headers
+
+	t.is(headers.get('Access-Control-Allow-Origin'), '*')
+	t.is(headers.get('Access-Control-Allow-Methods'), 'GET, POST, PATCH, OPTIONS')
+	t.is(headers.get('Access-Control-Allow-Headers'), 'Content-Type')
+
+	restore()
+
+})


### PR DESCRIPTION
Adds support for multiple origins without using wildcard (*) as per issue in #79 

Changes should not affect how existing configurations (no or single origin), and takes a whitelist approach to check the request's hostname, before return the origin to be set in the header.