### PR TITLE
Include origin header in check for supporting multiple hosts.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -53,7 +53,7 @@ const attachCorsHeaders = (fn) => async (req, res) => {
 
 		if (process.env.ACKEE_ALLOW_ORIGIN) {
 			const origins = process.env.ACKEE_ALLOW_ORIGIN.split(',')
-			return origins.find((origin) => origin.includes(req.headers.host))
+			return origins.find((origin) => origin.includes(req.headers.origin) || origin.includes(req.headers.host))
 		}
 
 	})()


### PR DESCRIPTION
Unfortunately, my previous pull request #82 that provides support for #79 didn't work in production for me. It would also have broken the CORS header for sites that specify a single origin. I apologize if anyone has been affected by the upgrade.

After some investigation, I've observed that in a production environment (for me it was deployed on Heroku), it is better to check using `req.headers.origin`, whereas in a local dev environment you have to check using `req.headers.host`.

This fix compares both against the array of origins, loaded from the env vars. I've deployed a fixed version from my fork in a production setting, so I can attest that this is working. Once again, sorry for any inconvenience.