### PR TITLE
Adding Ackee PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,6 @@ More documentation and guides are located in [the /docs folder](docs/). Also tak
 - [ackee-tracker](https://github.com/electerious/ackee-tracker) - Transfer data to Ackee
 - [gatsby-plugin-ackee-tracker](https://github.com/Burnsy/gatsby-plugin-ackee-tracker) - Gatsby plugin for Ackee
 - [Soapberry](https://wordpress.org/plugins/soapberry/) - WordPress plugin for Ackee
+- [Ackee-PHP](https://github.com/BrookeDot/ackee-php) - A PHP Class for Ackee
 - [use-ackee](https://github.com/electerious/use-ackee) - Use Ackee in React
 - [nuxt-ackee](https://github.com/bdrtsky/nuxt-ackee) - Nuxt.js module for Ackee


### PR DESCRIPTION
This adds the [Ackee PHP](https://github.com/BrookeDot/ackee-php) class to "related". I wrote the class to allow server-side options when adding the Ackee tracker to a PHP page. Currently support is pretty basic but it does allow for an `opt-out` cookie to be set by the visitor and respects DNT header.