### PR TITLE
Increase context class opacity

### DIFF
--- a/src/ui/styles/_vars.scss
+++ b/src/ui/styles/_vars.scss
@@ -8,7 +8,7 @@ $light: rgba(255, 255, 255, .5);
 $black: rgba(40, 45, 45, 1);
 $dimmed: rgba(255, 255, 255, .05);
 $card: rgba(51, 56, 56, 1);
-$context: rgba(69, 74, 74, .86);
+$context: rgba(69, 74, 74, .98);
 $border: rgba(0, 0, 0, .3);
 $success: rgba(0, 255, 0, .1);
 $warning: rgba(255, 255, 0, .1);


### PR DESCRIPTION
## Context

Text on menu is not readable enough when there is text below.

## Screenshots

### Before 

<img width="700" alt="Screenshot 2020-04-14 at 19 59 58" src="https://user-images.githubusercontent.com/6696530/79258176-081e9f80-7e8b-11ea-877d-3070379dd0b7.png">

### After
<img width="659" alt="Screenshot 2020-04-14 at 20 02 37" src="https://user-images.githubusercontent.com/6696530/79258182-09e86300-7e8b-11ea-80c5-9dff2c3110e7.png">