### PR TITLE
Add Django middleware to Related

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ I am working hard on continuously developing and maintaining Ackee. Please consi
 - [Ackee-PHP](https://github.com/BrookeDot/ackee-php) - A PHP Class for Ackee
 - [use-ackee](https://github.com/electerious/use-ackee) - Use Ackee in React
 - [nuxt-ackee](https://github.com/bdrtsky/nuxt-ackee) - Nuxt.js module for Ackee
+- [django-ackee-middleware](https://github.com/suda/django-ackee-middleware) - Django middleware for Ackee


### PR DESCRIPTION
I made a Django middleware to report requests w/o the JS tracker: [django-ackee-middleware](https://github.com/suda/django-ackee-middleware)
Hope it's useful :)