### PR TITLE
Fix: accept siteReferrer as empty string

### DIFF
--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -57,6 +57,7 @@ const normalizeSiteReferrer = (siteReferrer) => {
 
 	// The siteReferrer is optional
 	if (siteReferrer == null) return siteReferrer
+	if (siteReferrer === '') return null
 
 	try {
 


### PR DESCRIPTION
If the site has no referrer, document.referrer will be set to the empty string.
Currently, this will result in a 400 "Failed to normalize siteReferrer" error.