### PR TITLE
Add better scrollbars for supporting browsers

### DIFF
--- a/src/ui/styles/_scrollbar.scss
+++ b/src/ui/styles/_scrollbar.scss
@@ -1,0 +1,21 @@
+// Chromium ------------------------------------------------------ //
+
+::-webkit-scrollbar {
+  width: 6px;
+} 
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: $light;
+  border-radius: 3px;
+}
+
+// Firefox ------------------------------------------------------- //
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, .5) transparent;
+}

--- a/src/ui/styles/index.scss
+++ b/src/ui/styles/index.scss
@@ -36,6 +36,7 @@
 @import 'keyHint';
 @import 'updating';
 @import 'facts';
+@import 'scrollbar';
 
 // Helpers ----------------------------------------------------- //
 @import 'align';


### PR DESCRIPTION
This commit add better styling for scrollbars on Chromium and Firefox based browsers, this ones blend better in the design.

Here some pics to compare taken on Windows 10 on Brave browser (Chromium) and Firefox, OLD ➡️ NEW.


![wk-bar](https://user-images.githubusercontent.com/54755295/92289342-8507ef80-eee6-11ea-99ae-1e61e00f2d3c.png)
![ff-bar](https://user-images.githubusercontent.com/54755295/92289379-ab2d8f80-eee6-11ea-87b1-8b03bf2b1671.png)
