### PR TITLE
Better scrollbars for desktop browsers

### DIFF
--- a/src/ui/styles/_scrollbar.scss
+++ b/src/ui/styles/_scrollbar.scss
@@ -1,6 +1,7 @@
 // Chromium ------------------------------------------------------ //
 
 ::-webkit-scrollbar {
+  height: 6px;
   width: 6px;
 } 
 

--- a/src/ui/styles/_scrollbar.scss
+++ b/src/ui/styles/_scrollbar.scss
@@ -1,0 +1,21 @@
+// Chromium ------------------------------------------------------ //
+
+::-webkit-scrollbar {
+  width: 6px;
+} 
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: $light;
+  border-radius: 3px;
+}
+
+// Firefox ------------------------------------------------------- //
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: $light transparent;
+}

--- a/src/ui/styles/index.scss
+++ b/src/ui/styles/index.scss
@@ -36,6 +36,7 @@
 @import 'keyHint';
 @import 'updating';
 @import 'facts';
+@import 'scrollbar';
 
 // Helpers ----------------------------------------------------- //
 @import 'align';


### PR DESCRIPTION
Add better UI style for scrollbars on Chromium and Firefox based browser. For Firefox:

```
html, .input, .header__nav, .flexList__inner {
  scrollbar-width: thin;
  scrollbar-color: $light transparent;
}
```

can also be made, avoiding the "*" selector, but I'm not sure if these are all the elements that use scrollbars, there is also the option of creating an entire new class just for scrollbars.

Here some images taken on Windows 10, OLD ➡️ NEW.

![wk-bar](https://user-images.githubusercontent.com/54755295/92306702-9d6c1e80-ef67-11ea-9d4e-886635df55e5.png)
![ff-bar](https://user-images.githubusercontent.com/54755295/92306704-9e04b500-ef67-11ea-9f0f-4920699e33f4.png)