### PR TITLE
Fix for "Deploy to Heroku" button

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,11 +16,22 @@
     "ACKEE_PASSWORD": {
       "description": "Password which will be used to log in to Ackee",
       "required": true
+    },
+    "ACKEE_MONGODB": {
+      "description": "MongoDB URI which will be used to connect a database to Ackee",
+      "required": true
+    },
+    "ACKEE_ALLOW_ORIGIN": {
+      "description": "Tracked domains which will be used on Ackee (CORS headers)",
+      "required": true
+    },
+    "ACKEE_TTL": {
+      "description": "Specifies how long an Ackee TTL token is valid (Default: 3600000)",
+      "required": false
+    },
+    "ACKEE_TRACKER": {
+      "description": "Specifies a custom name for the tracking script (Default: tracker.js)",
+      "required": false
     }
-  },
-  "addons": [
-    {
-      "plan": "mongolab"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
As the title says, removed the deprecated dependecies (mLab addon), added some important (I think) environment variables in the the app creation. Now you directly need to link a database (e.g., MongoDB Atlas) to use Ackee.

Here is an example button:

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Go-Merk/Ackee/tree/heroku-fix)