### PR TITLE
Slim down the Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,6 @@ EXPOSE 3000
 
 WORKDIR /srv/app/
 
-# Add wait script to the image
-
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.5.0/wait /wait
-RUN chmod +x /wait
-
 # Copy and compile source in the last step as the source
 # might change the most.
 
@@ -39,4 +34,4 @@ COPY --from=build /srv/app/ /srv/app/
 HEALTHCHECK --interval=1m --timeout=45s --start-period=45s CMD [ "/srv/app/src/healthcheck.js" ]
 
 # Wait for external service and start Ackee
-CMD /wait && yarn server
+CMD yarn server

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=build /srv/app/ /srv/app/
 # Wait a bit before start to ensure the `yarn build` is done.
 HEALTHCHECK --interval=1m --timeout=45s --start-period=45s CMD [ "/srv/app/src/healthcheck.js" ]
 
-# Wait for external service and start Ackee
-CMD yarn server
+# Start Ackee
+CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir dist \
 	&& yarn build
 
 # Remove devDependencies by running install again, but only production dependencies
-RUN yarn install --production
+RUN yarn install --production --frozen-lockfile
 
 FROM mhart/alpine-node:14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,27 @@
+FROM mhart/alpine-node:14 AS build
+
+WORKDIR /srv/app/
+
+# Add dependencies first so that the docker image build can use
+# the cache as long as the dependencies stay unchanged.
+
+COPY package.json yarn.lock /srv/app/
+RUN yarn install --frozen-lockfile
+
+# Copy and compile source in the last step as the source
+# might change the most.
+COPY build.js /srv/app/
+COPY src /srv/app/src
+RUN mkdir dist \
+	&& yarn build
+
+# Remove devDependencies by running install again, but only production dependencies
+RUN yarn install --production
+
 FROM mhart/alpine-node:14
 
 EXPOSE 3000
 
-RUN mkdir -p /srv/app/
 WORKDIR /srv/app/
 
 # Add wait script to the image
@@ -10,20 +29,14 @@ WORKDIR /srv/app/
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.5.0/wait /wait
 RUN chmod +x /wait
 
-# Add dependencies first so that the docker image build can use
-# the cache as long as the dependencies stay unchanged.
-
-COPY package.json yarn.lock /srv/app/
-RUN yarn install
-
 # Copy and compile source in the last step as the source
 # might change the most.
 
-COPY . /srv/app/
+COPY --from=build /srv/app/ /srv/app/
 
 # Run healthcheck against MongoDB, server and API.
 # Wait a bit before start to ensure the `yarn build` is done.
 HEALTHCHECK --interval=1m --timeout=45s --start-period=45s CMD [ "/srv/app/src/healthcheck.js" ]
 
 # Wait for external service and start Ackee
-CMD /wait && yarn start
+CMD /wait && yarn server

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -6,5 +6,6 @@ module.exports = (dbUrl) => mongoose.connect(dbUrl, {
 	useFindAndModify: false,
 	useNewUrlParser: true,
 	useCreateIndex: true,
-	useUnifiedTopology: true
+	useUnifiedTopology: true,
+	connectTimeoutMS: 60000
 })


### PR DESCRIPTION
This changes to a multi-stage build, and To run the application, we only need `package.json`, `yarn.lock`, `build.js`, `node_modules` and `src/`

Changes done
- ensure what's in the lockfile is installed, keeps dependencies correct
- build the necessary files
- remove devDependencies
- copy files from build stage to runtime stage
- starts the server directly, brings down startup time significantly

Reduces the docker image with 193MB