### PR TITLE
Throw the errors in the healthcheck

### DIFF
--- a/src/healthcheck.js
+++ b/src/healthcheck.js
@@ -20,7 +20,7 @@ const checkServer = async (url) => {
 	const res = await fetch(url)
 
 	if (res.ok === false) {
-		new Error(`Server is unhealthy and returned with the status '${ res.status }'`)
+		throw new Error(`Server is unhealthy and returned with the status '${ res.status }'`)
 	}
 }
 
@@ -28,7 +28,7 @@ const checkApi = async (url) => {
 	const res = await fetch(url)
 
 	if (res.ok === false) {
-		new Error(`API is unhealthy and returned with the status '${ res.status }'`)
+		throw new Error(`API is unhealthy and returned with the status '${ res.status }'`)
 	}
 }
 


### PR DESCRIPTION
The errors has to be thrown, for `Promise.all` to be able to fail