### PR TITLE
Fix source in gql types

### DIFF
--- a/src/types/domainStatistics.js
+++ b/src/types/domainStatistics.js
@@ -57,7 +57,7 @@ module.exports = gql`
 
 	type Referrer {
 		"""
-		Either the URL of the referrer or the ref, source or utm_source parameter of the page to indicate where the visit comes from.
+		Either the URL of the referrer or the source parameter of the page to indicate where the visit comes from.
 		"""
 		id: String!
 		"""

--- a/src/types/records.js
+++ b/src/types/records.js
@@ -20,7 +20,7 @@ module.exports = gql`
 		"""
 		siteReferrer: URL
 		"""
-		Where the user came from. Either the ref, source or utm_source parameter.
+		Where the user came from. Specified using the source query parameter.
 		"""
 		source: String
 		"""
@@ -91,7 +91,7 @@ module.exports = gql`
 		"""
 		siteReferrer: URL
 		"""
-		Where the user came from. Either the ref, source or utm_source parameter.
+		Where the user came from. Specified using the source query parameter.
 		"""
 		source: String
 		"""


### PR DESCRIPTION
Removed `utm_source` and `ref` from [gql types](https://github.com/electerious/Ackee/blob/develop/src/types/records.js).