### PR TITLE
Added ackee-tracker-consent to the related part of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ I am working hard on continuously developing and maintaining Ackee. Please consi
 - [vuepress-plugin-ackee](https://github.com/spekulatius/vuepress-plugin-ackee) - VuePress plugin for Ackee
 - [svelte-ackee](https://github.com/gaia-green-tech/svelte-ackee) - Svelte module for Ackee
 - [ackee_dart](https://github.com/marchellodev/ackee_dart) - Ackee plugin for Dart/Flutter ([pub.dev](https://pub.dev/packages/ackee_dart))
+- [ackee-tracker-consent](https://www.npmjs.com/package/ackee-tracker-consent) - A consent banner to activate detailed tracking on Ackee
 
 
 ### Links


### PR DESCRIPTION
I made a consent banner with that you can let the user choose to either opt in or out of detailed tracking from Ackee. This way others don't have to write their own banner for their website.
You only need to add 4 lines to your HTML website and you are good to go!