### PR TITLE
Upgrade mongoose to 6.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "is-url": "^1.2.4",
     "micro": "^9.3.4",
     "microrouter": "^3.1.3",
-    "mongoose": "^5.11.17",
+    "mongoose": "^6.0.6",
     "node-fetch": "^2.6.1",
     "node-schedule": "^2.0.0",
     "normalize-url": "^5.0.0",

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -3,9 +3,7 @@
 const mongoose = require('mongoose')
 
 module.exports = (dbUrl) => mongoose.connect(dbUrl, {
-	useFindAndModify: false,
 	useNewUrlParser: true,
-	useCreateIndex: true,
 	useUnifiedTopology: true,
 	connectTimeoutMS: 60000
 })


### PR DESCRIPTION
Ackee is unable to connect to the new [Atlas Serverless](https://www.mongodb.com/community/forums/t/atlas-serverless-and-dns-txt-record/117967) due to older version of Mongoose. I followed the [migration guide](https://mongoosejs.com/docs/migrating_to_6.html) and now everything seems to be working.