### PR TITLE
Fix ACKEE_AUTO_ORIGIN not attaching CORS headers correctly

### DIFF
--- a/src/serverless.js
+++ b/src/serverless.js
@@ -21,10 +21,13 @@ const apolloServer = createApolloServer(ApolloServer, {
 const origin = (origin, callback) => {
 	if (config.autoOrigin === true) {
 		fullyQualifiedDomainNames()
-			.then((names) => callback(
-				null,
-				names.flatMap((name) => [ `http://${ name }`, `https://${ names }`, name ]),
-			))
+			.then((names) => {
+				console.log('Got qualified domains', names)
+				return callback(
+					null,
+					names.flatMap((name) => [ `http://${ name }`, `https://${ names }`, name ]),
+				)
+			})
 			.catch((error) => callback(error, false))
 		return
 	}

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -21,7 +21,10 @@ const apolloServer = createApolloServer(ApolloServer, {
 const origin = (origin, callback) => {
 	if (config.autoOrigin === true) {
 		fullyQualifiedDomainNames()
-			.then((names) => callback(null, names))
+			.then((names) => callback(
+				null,
+				names.flatMap((name) => [ `http://${ name }`, `https://${ names }`, name ]),
+			))
 			.catch((error) => callback(error, false))
 		return
 	}

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -21,13 +21,10 @@ const apolloServer = createApolloServer(ApolloServer, {
 const origin = (origin, callback) => {
 	if (config.autoOrigin === true) {
 		fullyQualifiedDomainNames()
-			.then((names) => {
-				console.log('Got qualified domains', names)
-				return callback(
-					null,
-					names.flatMap((name) => [ `http://${ name }`, `https://${ name }`, name ]),
-				)
-			})
+			.then((names) => callback(
+				null,
+				names.flatMap((name) => [ `http://${ name }`, `https://${ name }`, name ]),
+			))
 			.catch((error) => callback(error, false))
 		return
 	}
@@ -62,7 +59,5 @@ exports.handler = (event, context) => {
 		},
 	})
 
-	const response = handler(event, context)
-	response.then((value) => console.log('Response', value))
-	return response
+	return handler(event, context)
 }

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -25,7 +25,7 @@ const origin = (origin, callback) => {
 				console.log('Got qualified domains', names)
 				return callback(
 					null,
-					names.flatMap((name) => [ `http://${ name }`, `https://${ names }`, name ]),
+					names.flatMap((name) => [ `http://${ name }`, `https://${ name }`, name ]),
 				)
 			})
 			.catch((error) => callback(error, false))

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -59,5 +59,7 @@ exports.handler = (event, context) => {
 		},
 	})
 
-	return handler(event, context)
+	const response = handler(event, context)
+	response.then((value) => console.log('Response', value))
+	return response
 }


### PR DESCRIPTION
As mentioned in https://github.com/electerious/Ackee/issues/330#issuecomment-1126963836 it appears that `ACKEE_AUTO_ORIGIN` doesn't attach CORS headers correctly. Since `is-valid-domain` only returns true if there isn't a protocol, the qualified domains we extract from the Ackee domains will always be of the format `"example.com"`. It appears that express requires the returned CORS domain to be of the format `"https://example.com"`, otherwise it doesn't see it as a match to the incoming request. For a more in-depth explanation see the linked comment.

This fixes that issue by mapping each returned domain to both an HTTP and an HTTPS variant. For good measure I also included the original domain in the domain list we give to express - that shouldn't be needed, but it also shouldn't harm anything, and it protects against bugs in case I'm mistaken for some use case.

It should be noted that `.flatMap` is only supported in Node version 11+. It could be rewritten to use a `.reduce` instead if older versions of Node need to be supported.