### PR TITLE
Convert multiValueHeaders to headers on Vercel

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const handler = require('../src/serverless').handler
+
 /**
  * A serverless function handler for the '/api' route, for use with Vercel.
  * This handler follows the AWS Lambda API; Vercel deployments are opted-in
@@ -9,4 +11,28 @@
  *  - https://vercel.com/docs/serverless-functions/supported-languages#node.js
  *  - https://vercel.com/docs/runtimes#advanced-usage/advanced-node-js-usage/aws-lambda-api
  */
-exports.handler = require('../src/serverless').handler
+exports.handler = async (...args) => {
+	const response = await handler(...args)
+	return convertMultiValueHeaders(response)
+}
+
+/*
+ * At the time of writing the Vercel polyfill for the AWS Lambda API doesn't support .multiValueHeaders
+ * This stops us from attaching CORS headers to requests
+ * Since all the headers we commonly attach have a single value, we can map them to .headers instead
+ */
+const convertMultiValueHeaders = (response) => {
+	if (!(response instanceof Object) || !('multiValueHeaders' in response)) {
+		console.log('No multiValueHeaders, not converting')
+		return response
+	}
+	response.headers = response.headers || {}
+	for (const [ key, value ] of Object.entries(response.multiValueHeaders)) {
+		if (value.length === 1) {
+			response.headers[key] = value[0]
+		} else {
+			console.warn(`multiValueHeaders is currently unsupported on Vercel. Header ${key} will be ignored`)
+		}
+	}
+	return response
+}


### PR DESCRIPTION
As mentioned in #330 it appears that the polyfill used by Vercel to support the AWS Lambda API for serverless functions doesn't support `.multiValueHeaders`.  Since [`@vendia/serverless-express`](https://github.com/vendia/serverless-express) (which `apollo-server-lambda` relies on) uses `.multiValueHeaders` exclusively, this means that CORS headers aren't attached to requests correctly when hosting the project on Vercel. See the linked issue for more information.

Note that this *should* probably be fixed by Vercel, and I have opened a support case with them to make them aware of the problem. They say that their goal is to respond within 3-5 days, which we might want to wait for. This PR is more of a workaround until they fix their implementation of the AWS Lambda API.