### PR TITLE
Updated configuration to support Docker Swarm secrets

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,6 +1,7 @@
 # Options
 
-The following environment variables are used by Ackee. You can also create a [`.env` file](https://www.npmjs.com/package/dotenv) in the root of the project to store all variables in one file.
+The following environment variables are used by Ackee. You can also create a [`.env` file](https://www.npmjs.com/package/dotenv) in the root of the project to store all variables in one file. All environment
+variables also support a `_FILE` suffix, which will fetch the value from the specified file path.
 
 - [Database](#database)
 - [Port](#port)


### PR DESCRIPTION
Unlike secrets in Kubernetes and some other container orchestrators, Docker Swarm only allows you to mount secrets as files (rather annoyingly). I made a small update that allows you to store secret values on the file system then specify the path to said secret values as environment variables.

Hopefully this change is useful to someone else. Thanks for the excellent work on Ackee!