### PR TITLE
 fix: switched stripUrlAuth to a regex

### DIFF
--- a/src/utils/stripUrlAuth.js
+++ b/src/utils/stripUrlAuth.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const normalizeUrl = require('normalize-url')
+module.exports = (url) => {
+	if (typeof url !== 'string') {
+		throw new TypeError('Expected a valid URL')
+	}
 
-module.exports = (url) => normalizeUrl(url, {
-	normalizeProtocol: false,
-	stripWWW: false,
-	removeTrailingSlash: false,
-	sortQueryParameters: false,
-})
+	return url.replace(/^((?:\w+:)?\/\/)[^@/]+@/, '$1')
+}


### PR DESCRIPTION
This PR tries to fix the bug report #310.
Instead of using the normalize-url to parse and remove the username and password from the URL, which fails when the url have multiple hostnames, i use a regex.