### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Get Ackee up and running…
 - […with Railway](docs/Get%20started.md#with-railway)
 - […with Koyeb](docs/Get%20started.md#with-koyeb)
 - […with Zeabur](docs/Get%20started.md#with-zeabur)
+- […with RepoCloud](docs/Get%20started.md#with-repocloud)
 
 And configure Ackee and your server correctly…
 

--- a/docs/Get started.md
+++ b/docs/Get started.md
@@ -19,6 +19,7 @@ The node server shows you the UI and receives the request from all of your sites
 - [With Railway](#with-railway)
 - [With Koyeb](#with-koyeb)
 - [With Zeabur](#with-zeabur)
+- [With RepoCloud](#with-repocloud)
 
 ## With Docker Compose
 
@@ -319,7 +320,7 @@ $ koyeb secret create ackee-password
 ✔ Enter your secret: <ackee_password>
 ```
 
-Once you’ve created the secrets, you can deploy Ackee. In your terminal run the following command to create a new Koyeb App and deploy the Ackee service.
+Once you've created the secrets, you can deploy Ackee. In your terminal run the following command to create a new Koyeb App and deploy the Ackee service.
 
 ```sh
 koyeb app init ackee --docker electerious/ackee --ports 3000:http --routes /:3000 --env ACKEE_USERNAME=@ackee-username --env ACKEE_PASSWORD=@ackee-password --env ACKEE_MONGODB=@mongodb-url --env ACKEE_ALLOW_ORIGIN="https://example.com"
@@ -343,3 +344,11 @@ You can use the [Zeabur](https://zeabur.com/) button for a one-click deployment 
 
 Upon clicking the button, you will be asked to set the `ACKEE_USERNAME` environment variables. Once you do that, everything should just work on its own.
 Zeabur will automatically provision the MongoDB database for you and also link it to your Ackee deployment!
+
+## With RepoCloud
+
+You can use the [RepoCloud](https://repocloud.io/) button below for a one-click deployment and have Ackee running within minutes.
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Ackee/)
+
+RepoCloud will automatically provision the required infrastructure and handle all the configuration. Once deployed, you can access your Ackee instance via the provided URL and start tracking your website analytics right away.


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option alongside the existing providers (Netlify, Vercel, Heroku, Qovery, Render, Railway, Koyeb, Zeabur).

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment, automatic infrastructure provisioning, and free credits for new users.

- Adds deploy button to `docs/Get started.md`
- Adds table of contents entry in `docs/Get started.md`
- Adds navigation link in `README.md`
- Uses the same format/style as existing deploy buttons (Zeabur pattern)
- Links to: https://repocloud.io/details/Ackee/